### PR TITLE
Allow newer versions of hapijs and add rethinkdb-init support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 hapi-rethinkdb
 ==============
 
-Hapi (^8.0) plugin for `rethinkdb` [native driver](https://www.npmjs.com/package/rethinkdb).
+Hapi (>=8.0) plugin for `rethinkdb` [native driver](https://www.npmjs.com/package/rethinkdb).
 
 Install hapi-rethinkdb
 ----------------------

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/ghostbar/hapi-rethinkdb",
   "dependencies": {
+    "rethinkdb-init": "0.0.5"
   },
   "devDependencies": {
     "hapi": ">=8.2.0",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "dependencies": {
   },
   "devDependencies": {
-    "hapi": "^8.2.0",
+    "hapi": ">=8.2.0",
     "rethinkdb": "^2.0.0",
     "mocha": "^2.1.0"
   },
   "peerDependencies": {
-    "hapi": "^8.2.0",
+    "hapi": ">=8.2.0",
     "rethinkdb": "^2.0.0"
   }
 }


### PR DESCRIPTION
The peerDependency locked hapi into v8, this allows all version above that.

I really liked the other fork but I think it went to far, this just adds the rethinkdb-init library.

I can update the docs in another pull request if you think these changes are reasonable.
