### PR TITLE
Allow to pass connection parameters as plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Install hapi-rethinkdb
 Register plugin
 ---------------
 
-You can pass as options either an URL (all are optionals, defaults to: no password, localhost and ) or `host` and `port`. Obviously passing an URL is way more convenient (specially for 12factor-compliant apps).
-
+You can pass as options either an URL or `host` and `port`. Obviously passing an URL is way more convenient (specially for 12factor-compliant apps).
+```js
     var Hapi = require('hapi');
     var server = new Hapi.Server();
 
@@ -22,6 +22,18 @@ You can pass as options either an URL (all are optionals, defaults to: no passwo
     }, function (err) {
       if (err) console.error(err);
     });
+```
+
+##### Options
+* `url`: the URL of your RethinkDB instance in form `rethinkdb://password@domain.tld:port/dbname`, default to `rethinkdb://localhost:28015/test`
+
+or
+
+* `host`: the hostname of your RethinkDB instance, default to `localhost`
+* `port`: the port of your RethinkDB instance, default to `28015`
+* `db`: the name of your RethinkDB database, default to `test`
+* `password`: the authentication key to access your RethinkDB, defaults to *no password*
+
 
 Use plugin
 ----------
@@ -30,6 +42,7 @@ The connection object returned by `rethinkdb.connect` callback is exposed on `se
 
 From a handler you can use it like:
 
+```js
     function handler (request, response) {
       var r = request.server.plugins['hapi-rethinkdb'].rethinkdb;
       // r === this.rethinkdb;
@@ -41,6 +54,7 @@ From a handler you can use it like:
         cursor.each(console.log);
       });
     }
+```
 
 License
 -------

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ exports.register = function (plugin, opts, next) {
     opts.port = opts.port || 28015
     opts.host = opts.host || 'localhost'
     opts.db = opts.db || 'test'
+
+    if (opts.password) {
+      opts.authKey = opts.password
+    }
   } else {
     var url = require('url').parse(opts.url)
     opts.port = parseInt(url.port, 10) || 28015

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ exports.register = function (plugin, opts, next) {
       opts.authKey = url.auth.split(':')[1]
   }
 
+  if (opts.url && (opts.host || opts.port || opts.db || opts.password)) {
+    plugin.log(['hapi-rethinkdb', 'warn'], 'Define either an URL or host, port, db and password variables')
+  }
+
   rethink.connect(opts, function (err, conn) {
     if (err) {
       plugin.log(['hapi-rethinkdb', 'error'], err.message)

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "dependencies": {
   },
   "devDependencies": {
-    "hapi": ">=8.2.0",
-    "rethinkdb": "^2.0.0",
-    "mocha": "^2.1.0"
+    "hapi": ">=11.1.1",
+    "rethinkdb": "^2.2.0",
+    "mocha": "^2.3.4"
   },
   "peerDependencies": {
-    "hapi": ">=8.2.0",
-    "rethinkdb": "^2.0.0"
+    "hapi": ">=11.1.1",
+    "rethinkdb": "^2.2.0"
   }
 }

--- a/test/connection.js
+++ b/test/connection.js
@@ -73,4 +73,76 @@ describe('Testing Hapi RethinkDB plugin', function () {
     })
   })
 
+  it('should connect taking the port and the host as an option', function (done) {
+    server.register({
+      register: require('../'),
+      options: {
+        host: 'localhost',
+        port: 28015
+      }
+    }, function () {
+      assert(
+        server.plugins['hapi-rethinkdb'].connection.host === 'localhost',
+        'Connected to incorrect address'
+      )
+      assert(
+        server.plugins['hapi-rethinkdb'].connection.port === 28015,
+        'Connected to incorrect port'
+      )
+      done()
+    })
+  })
+
+  it('should connect to the default port passing only the hostname as an option', function (done) {
+    server.register({
+      register: require('../'),
+      options: { host: 'localhost' }
+    }, function () {
+      assert(
+        server.plugins['hapi-rethinkdb'].connection.host === 'localhost',
+        'Connected to incorrect address'
+      )
+      assert(
+        server.plugins['hapi-rethinkdb'].connection.port === 28015,
+        'Connected to incorrect port'
+      )
+      done()
+    })
+  })
+
+
+  it('should connect to the default host passing only the port number as an option', function (done) {
+    server.register({
+      register: require('../'),
+      options: { port: 28015 }
+    }, function () {
+      assert(
+        server.plugins['hapi-rethinkdb'].connection.host === 'localhost',
+        'Connected to incorrect address'
+      )
+      assert(
+        server.plugins['hapi-rethinkdb'].connection.port === 28015,
+        'Connected to incorrect port'
+      )
+      done()
+    })
+  })
+
+  it('should connect to the default host and port passing only the database name as an option', function (done) {
+    server.register({
+      register: require('../'),
+      options: { db: 'newtest' }
+    }, function () {
+      assert(
+        server.plugins['hapi-rethinkdb'].connection.host === 'localhost',
+        'Connected to incorrect address'
+      )
+      assert(
+        server.plugins['hapi-rethinkdb'].connection.port === 28015,
+        'Connected to incorrect port'
+      )
+      done()
+    })
+  })
+
 })


### PR DESCRIPTION
I know it was already possible, but I've tried to make this more clear in the README.
I've also added some tests and the chace to pass the authentication key as option.

What do you think about it ?
