### PR TITLE
Update Example with correct options param name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can pass as options either an URL (all are optionals, defaults to: no passwo
 
     server.register({
       register: require('hapi-rethinkdb'),
-      opts: { url: 'rethinkdb://:password@domain.tld:port/dbname' }
+      options: { url: 'rethinkdb://:password@domain.tld:port/dbname' }
     }, function (err) {
       if (err) console.error(err);
     });


### PR DESCRIPTION
The `opts` keyword doesn't seem to work when registering a plugin. The correct syntax is `options` as seen in the [official documentation](http://hapijs.com/tutorials/plugins).
